### PR TITLE
Wandboard: Use 0x11000000 as the ubldr load address

### DIFF
--- a/board/Wandboard/files/boot.txt
+++ b/board/Wandboard/files/boot.txt
@@ -1,2 +1,2 @@
-setenv fdt_file wandboard-quad.dtb;fatload mmc 0:1 88000000 ubldr;bootelf 88000000;
+setenv fdt_file wandboard-quad.dtb;fatload mmc 0:1 11000000 ubldr;bootelf 11000000;
 

--- a/board/Wandboard/setup.sh
+++ b/board/Wandboard/setup.sh
@@ -64,7 +64,7 @@ wandboard_install_uenvtxt(){
 wandboard_install_dts_fat(){
     echo "Installing DTS to FAT"
     freebsd_install_fdt wandboard-quad.dts wandboard-quad.dts
-    freebsd_install_fdt wandboard-quad.dts wandboard-quad.dtb
+    freebsd_install_fdt wandboard-quad.dtb wandboard-quad.dtb
 }
 #strategy_add $PHASE_BOOT_INSTALL wandboard_install_dts_fat
 
@@ -74,7 +74,7 @@ wandboard_install_dts_fat(){
 wandboard_install_dts_ufs(){
     echo "Installing DTS to UFS"
     freebsd_install_fdt wandboard-quad.dts boot/kernel/wandboard-quad.dts
-    freebsd_install_fdt wandboard-quad.dts boot/kernel/wandboard-quad.dtb
+    freebsd_install_fdt wandboard-quad.dtb boot/kernel/wandboard-quad.dtb
 }
 strategy_add $PHASE_FREEBSD_BOARD_POST_INSTALL wandboard_install_dts_ufs
 

--- a/board/Wandboard/setup.sh
+++ b/board/Wandboard/setup.sh
@@ -64,7 +64,7 @@ wandboard_install_uenvtxt(){
 wandboard_install_dts_fat(){
     echo "Installing DTS to FAT"
     freebsd_install_fdt wandboard-quad.dts wandboard-quad.dts
-    freebsd_install_fdt wandboard-quad.dtb wandboard-quad.dtb
+    freebsd_install_fdt wandboard-quad.dts wandboard-quad.dtb
 }
 #strategy_add $PHASE_BOOT_INSTALL wandboard_install_dts_fat
 
@@ -74,7 +74,7 @@ wandboard_install_dts_fat(){
 wandboard_install_dts_ufs(){
     echo "Installing DTS to UFS"
     freebsd_install_fdt wandboard-quad.dts boot/kernel/wandboard-quad.dts
-    freebsd_install_fdt wandboard-quad.dtb boot/kernel/wandboard-quad.dtb
+    freebsd_install_fdt wandboard-quad.dts boot/kernel/wandboard-quad.dtb
 }
 strategy_add $PHASE_FREEBSD_BOARD_POST_INSTALL wandboard_install_dts_ufs
 

--- a/board/Wandboard/setup.sh
+++ b/board/Wandboard/setup.sh
@@ -46,7 +46,7 @@ wandboard_uboot_install ( ) {
 #
 # ubldr
 #
-strategy_add $PHASE_BUILD_OTHER freebsd_ubldr_build UBLDR_LOADADDR=0x88000000
+strategy_add $PHASE_BUILD_OTHER freebsd_ubldr_build UBLDR_LOADADDR=0x11000000
 strategy_add $PHASE_BOOT_INSTALL freebsd_ubldr_copy_ubldr ubldr
 
 #


### PR DESCRIPTION
0x88000000 is too large for Dual and Solo boards.

Also fixes some typos copying dtb files.